### PR TITLE
fix google takeout vcard edge case

### DIFF
--- a/abook.py
+++ b/abook.py
@@ -268,7 +268,10 @@ class Abook:
     def _conv_adr(adr: Component, entry: SectionProxy) -> None:
         """Convert to Abook address format."""
         if adr.value.street:
-            entry["address"] = adr.value.street
+            if isinstance(adr.value.street , list):
+                entry["address"] = ",".join(adr.value.street)
+            else:
+                entry["address"] = adr.value.street
         if adr.value.extended:
             entry["address2"] = adr.value.extended
         if adr.value.city:


### PR DESCRIPTION
I had to modify abook to process a google takeout workload.

A particular street value was a list- I am unsure why, it was split on a comma.

This is not an in-depth fix but a quick, shallow one, but it did help me use abook quickly. Placing it here in the hopes it might be useful. Feel free to ask questions.