### PR TITLE
fix: vcf2abook - append vcf to addressbook, if addressbook exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Install
 
 :: 
 
-  git clone git@github.com:jspricke/python-abook.git
+  git clone https://github.com/jspricke/python-abook.git
   cd python-abook
 
   # builds the library (for use in your own scripts)

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,6 @@ Additionally python-abook can convert your abook addressbook to .vcf format:
 
 
   # convert vcf contact/s and write them to your addressbook
-  # NOTE: This will OVERWRITE your entire addressbook with the contents of input vcf
 
   $ vcf2abook --help
   $ vcf2abook ~/path/to/contact.vcf ~/path/to/abook/addressbook

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ Additionally python-abook can convert your abook addressbook to .vcf format:
 
 
   # convert vcf contact/s and write them to your addressbook
+  # NOTE: This will OVERWRITE your entire addressbook with the contents of input vcf
 
   $ vcf2abook --help
   $ vcf2abook ~/path/to/contact.vcf ~/path/to/abook/addressbook

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,11 @@ Additionally python-abook can convert your abook addressbook to .vcf format:
   $ abook2vcf --help
   $ abook2vcf ~/path/to/abook/addressbook ~/path/to/write/contacts.vcf
 
+  # ommit the output file to print results to stdout
+
+  $ abook2vcf ~/path/to/abook/addressbook
+
+
   # convert vcf contact/s and write them to your addressbook
 
   $ vcf2abook --help

--- a/README.rst
+++ b/README.rst
@@ -14,3 +14,37 @@ Configuration
   view ADDRESS = address, address2, city, state, zip, country
   view PHONE = phone, workphone, mobile, other
   view OTHER = nick, url, notes
+
+Install
+------------------
+
+:: 
+
+  git clone git@github.com:jspricke/python-abook.git
+  cd python-abook
+
+  # builds the library (for use in your own scripts)
+  python3 setup.py build
+
+  # installs executables `abook2vcf` `vcf2abook` to $PATH 
+  # mac (/opt/homebrew/bin)
+  # linux?
+  # windows?
+  python3 setup.py install
+
+Usage
+-----
+
+python-abook converts vcards (.vcf files) and writes them to your abook addressbook. 
+It can also handle .vcf files containing multiple contacts. 
+Additionally python-abook can convert your abook addressbook to .vcf format:
+
+:: 
+
+  $ abook2vcf --help
+  $ abook2vcf ~/path/to/abook/addressbook ~/path/to/write/contacts.vcf
+
+  $ vcf2abook --help
+  $ vcf2abook ~/path/to/contact.vcf ~/path/to/abook/addressbook
+
+

--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,6 @@ Install
 
   # installs executables `abook2vcf` `vcf2abook` to $PATH 
   # mac (/opt/homebrew/bin)
-  # linux?
-  # windows?
   python3 setup.py install
 
 Usage
@@ -41,8 +39,12 @@ Additionally python-abook can convert your abook addressbook to .vcf format:
 
 :: 
 
+  # convert your address book to vcf (one vcf file contatining all contacts)
+
   $ abook2vcf --help
   $ abook2vcf ~/path/to/abook/addressbook ~/path/to/write/contacts.vcf
+
+  # convert vcf contact/s and write them to your addressbook
 
   $ vcf2abook --help
   $ vcf2abook ~/path/to/contact.vcf ~/path/to/abook/addressbook


### PR DESCRIPTION
`vcf2abook` overwrites the address book. Is there an `append` function or flag? I didn't spot any.

Added .gitignore with `.DS.Store` entry for mac.