### PR TITLE
Vcf2abook append

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,177 @@
+# Created by https://www.toptal.com/developers/gitignore/api/python
+# Edit at https://www.toptal.com/developers/gitignore?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+# End of https://www.toptal.com/developers/gitignore/api/python
+n

--- a/.gitignore
+++ b/.gitignore
@@ -174,4 +174,5 @@ poetry.toml
 pyrightconfig.json
 
 # End of https://www.toptal.com/developers/gitignore/api/python
-n
+
+ignored/

--- a/abook.py
+++ b/abook.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Python library to convert between Abook and vCard."""
 
+import os
 from collections.abc import Iterable
 from configparser import ConfigParser, SectionProxy
 from hashlib import sha1
@@ -396,4 +397,12 @@ def vcf2abook() -> None:
     )
     args = parser.parse_args()
 
-    Abook.abook_file(args.infile, args.outfile)
+    if os.path.isfile(args.outfile):
+        abook = Abook(args.outfile)
+        for vcard in args.infile:
+            if vcard in abook.get_uids():
+                Abook.replace_vobject(vcard.uid, vcard, args.outfile)
+            else:
+                abook.append_vobject(vcard, args.outfile)
+    else:
+        Abook.abook_file(args.infile, args.outfile)

--- a/abook.py
+++ b/abook.py
@@ -17,6 +17,7 @@
 """Python library to convert between Abook and vCard."""
 
 import os
+import re
 from collections.abc import Iterable
 from configparser import ConfigParser, SectionProxy
 from hashlib import sha1
@@ -397,15 +398,15 @@ def vcf2abook() -> None:
     )
     args = parser.parse_args()
 
+    
     if os.path.isfile(args.outfile):
         abook = Abook(args.outfile)
-        for vcard in args.infile:
-            if vcard in abook.get_uids():
-                print("vcard is in abook")
-                # abook.replace_vobject(vcard, vcard)
-            else:
+        abook_uids = abook.get_uids()
+        for line in args.infile:
+            if re.search(re.compile("FN:"), line):
+                full_name = line.strip("FN:")
 
-                print("vcard is NOT in abook")
-                # abook.append_vobject(vcard)
     else:
         Abook.abook_file(args.infile, args.outfile)
+
+vcf2abook()

--- a/abook.py
+++ b/abook.py
@@ -401,8 +401,11 @@ def vcf2abook() -> None:
         abook = Abook(args.outfile)
         for vcard in args.infile:
             if vcard in abook.get_uids():
-                Abook.replace_vobject(vcard.uid, vcard, args.outfile)
+                print("vcard is in abook")
+                # abook.replace_vobject(vcard, vcard)
             else:
-                abook.append_vobject(vcard, args.outfile)
+
+                print("vcard is NOT in abook")
+                # abook.append_vobject(vcard)
     else:
         Abook.abook_file(args.infile, args.outfile)


### PR DESCRIPTION
After some initial playing around, I'm left unsure about a few things:

Despite creating a brand new `addressbook` with `vcf2abook`, running the same command again, with the logic added in `abook.py` sends me to the `else` block (i.e "...does NOT exist")

e.g. 
```bash
$ vcf2abook ~/Downloads/person.vcf /tmp/abook1 && vcf2abook ~/Downloads/person.vcf /tmp/abook1
```
output
```text
~/.local/src/python-abook vcf2abook-append* ≡
sys ❯ vcf2abook ~/Downloads/test_person.vcf /tmp/abook_test

~/.local/src/python-abook vcf2abook-append* ≡
sys ❯ vcf2abook ~/Downloads/test_person.vcf /tmp/abook_test
BEGIN:VCARD

vcard is NOT in abook
VERSION:3.0

vcard is NOT in abook
PRODID:-//Apple Inc.//macOS 13.5//EN

vcard is NOT in abook
N:Test;Person;;;

vcard is NOT in abook
FN:Test Person

vcard is NOT in abook
ORG:Vabali;

vcard is NOT in abook
EMAIL;type=INTERNET;type=HOME;type=pref:test.person@email.com

vcard is NOT in abook
END:VCARD

vcard is NOT in abook
```

My questions then become many, but my main question is how is the list of ids returned by `get_uids` supposed to be used as a check against the vcard/s provided by `args.infile`? From what I understand, UIDs are generated from the abook contact entries (by `_gen_uid`?), so how is it working that the elements of the vcard are checked against this UID type?

Also, it's ok if I should just be directed to google, but I'm also unsure how to run the `vcf2abook` portion of the `abook.py`  script with my debugger (debugpy), as the debugger wants to run the `abook.py` file itself for debugging, but the `vcf2abook` is only runable as an installed executable? 